### PR TITLE
Support inline blocks by not removing outer whitespace (but add option to remove outer whitespace)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,65 @@
 /*jslint node:true */
 "use strict";
 
+var projectName = require("./package.json").name;
 var loaderUtils = require("loader-utils");
+var regexCharsRegex = /[-[\]{}()*+?.,\\^$\/|#]/g;
+
+function escapeRegexChars(comment) {
+    return comment && regexCharsRegex.test(comment)
+        ? comment.replace(regexCharsRegex, '\\$&')
+        : comment;
+}
 
 function StripBlockLoader(content) {
     var options = loaderUtils.getOptions(this) || {};
     var startComment = options.start || 'develblock:start';
     var endComment = options.end || 'develblock:end';
+    var removeOuterWhitespace = options.removeOuterWhitespace === true;
+    var omitReplacementMarker = options.omitReplacementMarker === true;
+    var startWhitespaceMatcher = "";
+    var endWhitespaceMatcher = "";
+    var whitespaceMatcher = "[\\t ]*";
 
-    var regexPattern = new RegExp("[\\t ]*\\/\\* ?" + startComment + " ?\\*\\/[\\s\\S]*?\\/\\* ?" + endComment + " ?\\*\\/[\\t ]*\\n?", "g");
+    // in case there are any regex chars in the comment string itself
+    startComment = escapeRegexChars(startComment);
+    endComment = escapeRegexChars(endComment);
 
-    content = content.replace(regexPattern, '');
+    // if removeOuterWhitespace is true, remove whitespace on
+    // the line outside of the comment tags to start and end
+    // the dev block
+    if (removeOuterWhitespace) {
+        startWhitespaceMatcher = "^" + whitespaceMatcher;
+        endWhitespaceMatcher = whitespaceMatcher + "\\n?"
+    }
+    var regexPattern = new RegExp(startWhitespaceMatcher +
+            "\\/\\* ?" + startComment + " ?\\*\\/[\\s\\S]*?\\/\\* ?" + 
+            endComment + " ?\\*\\/" + endWhitespaceMatcher, "g");
+
+    var startWhitespaceMatcher = "";
+    var endWhitespaceMatcher = "";
+    var whitespaceMatcher = "[\\t ]*"
+    // if removeOuterWhitespace is true, remove whitespace on
+    // the line outside of the comment tags to start and end
+    // the dev block
+    if (removeOuterWhitespace) {
+        startWhitespaceMatcher = "^" + whitespaceMatcher;
+        endWhitespaceMatcher = whitespaceMatcher + "\\n?"
+    }
+    var regexPattern = new RegExp(startWhitespaceMatcher +
+            "\\/\\* ?" + startComment + " ?\\*\\/[\\s\\S]*?\\/\\* ?" + 
+            endComment + " ?\\*\\/" + endWhitespaceMatcher, "g");
+
+    // format the replacement comment str, but omit the replacement
+    // comment entirely if empty string is passed in as the value
+    // for the 'replacementText' option
+    var replacement = (typeof options.replacementText === 'string')
+        ? escapeRegexChars(options.replacementText)
+        : (omitReplacementMarker ? '' : (projectName + ':removed'));
+    replacement = (!!replacement)
+        ? ('/* ' + replacement + ' */')
+        : '';
+    content = content.replace(regexPattern, replacement);
 
     if (this.cacheable) {
         this.cacheable(true);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "webpack-strip-block",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "webpack-strip-block",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Webpack plugin to strip blocks of code that's only intended for development purposes",
     "main": "index.js",
     "repository": {

--- a/test/fixtures/example-no-outer-whitespace.js
+++ b/test/fixtures/example-no-outer-whitespace.js
@@ -1,0 +1,3 @@
+const  addFour = (num) => ('   '.length + /* DEV:START */ 0 + /* DEV:END */ num);
+
+module.exports = addFour;

--- a/test/fixtures/example-regex-chars.js
+++ b/test/fixtures/example-regex-chars.js
@@ -1,0 +1,18 @@
+class TestRegexChars {
+    usingDot() {
+        /* DEV.START */ console.log('should vanish'); /* DEV.END */
+        return 1 + /* DEV.START */ 0 + /* DEV.END */ 1;
+    }
+    usingPlus() {
+        /* DEV+START */ console.log('should vanish'); /* DEV+END */
+        return 1 + /* DEV+START */ 0 + /* DEV+END */ 1;
+    }
+    usingBackslash() {
+        /* DEV\START */ console.log('should vanish'); /* DEV\END */
+        return 1 + /* DEV\START */ 0 + /* DEV\END */ 1;
+    }
+    usingDollarSign() {
+        /* DEV$START */ console.log('should vanish'); /* DEV$END */
+        return 1 + /* DEV$START */ 0 + /* DEV$END */ 1;
+    }
+}

--- a/test/spec.js
+++ b/test/spec.js
@@ -5,8 +5,9 @@ const EXPECTED_OUTPUT_BASIC_CASE = `
 /* this comment should not be removed */
 module.exports = function addOne(num) {
     const one = 1;
+    /* webpack-strip-block:removed */
     return num + one;
-}`
+}`;
 
 const EXPECTED_OUTPUT_CUSTOM_TAGS = `
 const ONE_STR = 1;
@@ -16,23 +17,87 @@ const ONE_STR = 1;
 const addTwo = (num = 0) => {
     // this comment should not be removed
     const one = parseInt(TWO_STR, 10);
+    /* webpack-strip-block:removed */
     const numPlusOne = num + one;
+    /* webpack-strip-block:removed */
     const numPlusTwo = numPlusOne + one;
     return numPlusTwo;
 };
 
-module.exports = addTwo;`
+module.exports = addTwo;`;
 
 const EXPECTED_OUTPUT_INLINE = `function addThree(num) {
     const arr = '1 1 1'.split(' ');
     const three = arr.reduce((acc, el) => {
-        return acc +parseInt(el, 10);
+        return acc + /* webpack-strip-block:removed */ parseInt(el, 10);
     }, 0);
     return num + three;
 }
 
 module.exports = addThree;
-`
+`;
+
+const EXPECTED_OUTPUT_INLINE_REGEX_CHARS_1 = `class TestRegexChars {
+    usingDot() {
+        /* webpack-strip-block:removed */
+        return 1 + /* webpack-strip-block:removed */ 1;
+    }
+    usingPlus() {
+        /* DEV+START */ console.log('should vanish'); /* DEV+END */
+        return 1 + /* DEV+START */ 0 + /* DEV+END */ 1;
+    }
+    usingBackslash() {
+        /* DEV\\START */ console.log('should vanish'); /* DEV\\END */
+        return 1 + /* DEV\\START */ 0 + /* DEV\\END */ 1;
+    }
+    usingDollarSign() {
+        /* DEV$START */ console.log('should vanish'); /* DEV$END */
+        return 1 + /* DEV$START */ 0 + /* DEV$END */ 1;
+    }
+}`;
+
+const EXPECTED_OUTPUT_INLINE_REGEX_CHARS_2 = `class TestRegexChars {
+    usingDot() {
+        /* DEV.START */ console.log('should vanish'); /* DEV.END */
+        return 1 + /* DEV.START */ 0 + /* DEV.END */ 1;
+    }
+    usingPlus() {
+        /* webpack-strip-block:removed */
+        return 1 + /* webpack-strip-block:removed */ 1;
+    }
+    usingBackslash() {
+        /* DEV\\START */ console.log('should vanish'); /* DEV\\END */
+        return 1 + /* DEV\\START */ 0 + /* DEV\\END */ 1;
+    }
+    usingDollarSign() {
+        /* DEV$START */ console.log('should vanish'); /* DEV$END */
+        return 1 + /* DEV$START */ 0 + /* DEV$END */ 1;
+    }
+}`;
+
+const EXPECTED_OUTPUT_INLINE_REGEX_CHARS_3 = `class TestRegexChars {
+    usingDot() {
+        /* DEV.START */ console.log('should vanish'); /* DEV.END */
+        return 1 + /* DEV.START */ 0 + /* DEV.END */ 1;
+    }
+    usingPlus() {
+        /* DEV+START */ console.log('should vanish'); /* DEV+END */
+        return 1 + /* DEV+START */ 0 + /* DEV+END */ 1;
+    }
+    usingBackslash() {
+        /* webpack-strip-block:removed */
+        return 1 + /* webpack-strip-block:removed */ 1;
+    }
+    usingDollarSign() {
+        /* DEV$START */ console.log('should vanish'); /* DEV$END */
+        return 1 + /* DEV$START */ 0 + /* DEV$END */ 1;
+    }
+}`;
+
+const EXPECTED_OUTPUT_NO_OUTER_WHITESPACE = `const  addFour = (num) => ('   '.length + /* DEV:START */ 0 + /* DEV:END */ num);
+
+module.exports = addFour;
+`;
 
 describe('webpack-strip-block', () => {
     describe('basic case', () => {
@@ -66,6 +131,40 @@ describe('webpack-strip-block', () => {
             });
             const output = stats.toJson().modules[0].source;
             assert.equal(output, EXPECTED_OUTPUT_INLINE);
+        });
+        describe('using regex chars in tags', () => {
+            const runUsingDevblockWith = async (char) => {
+                const stats = await testCompiler('fixtures/example-regex-chars', {
+                    options: {
+                        start: `DEV${char}START`,
+                        end: `DEV${char}END`
+                    }
+                });
+                return stats.toJson().modules[0].source;
+            };
+            it('removes the appropriate block and leaves other code unchanged', async () => {
+                let output = await runUsingDevblockWith('.');
+                assert.equal(output, EXPECTED_OUTPUT_INLINE_REGEX_CHARS_1);
+                output = await runUsingDevblockWith('+');
+                assert.equal(output, EXPECTED_OUTPUT_INLINE_REGEX_CHARS_2);
+                output = await runUsingDevblockWith('\\');
+                assert.equal(output, EXPECTED_OUTPUT_INLINE_REGEX_CHARS_3);
+                output = await runUsingDevblockWith('$');
+            });
+        })
+    });
+
+    describe('removing outer whitespace', () => {
+        it('removes the appropriate block and leaves other code unchanged', async () => {
+            const stats = await testCompiler('fixtures/example-no-outer-whitespace', {
+                options: {
+                    start: 'DEV:START',
+                    end: 'DEV:END',
+                    removeOuterWhitespace: true
+                }
+            });
+            const output = stats.toJson().modules[0].source;
+            assert.equal(output, EXPECTED_OUTPUT_NO_OUTER_WHITESPACE);
         });
     });
 });


### PR DESCRIPTION
Support inline blocks by not expecting lines with the "start" or "end" comment tags to be take the entire line outside of whitespace. You can continue to preserve the existing functionality by passing `removeOuterWhitespace: true` as an option.

Additionally, added replacement comment markers so you can find where code was removed in production. You can remove these with the `omitReplacementMarker` option.