### PR TITLE
Support multiple comment tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,27 @@ module.exports = {
   ]
 };
 ```
+
+If you need to use multiple comment tags to mark the start and end of the block to strip from your code, you can add options for "start" and "end" like this:
+
+```javascript
+module.exports = {
+  rules: [
+    {
+      test: /\.js$/,
+      enforce: 'pre',
+      exclude: /(node_modules|bower_components|\.spec\.js)/,
+      use: [
+        {
+          loader: 'webpack-strip-block',
+          options: {
+            start: ['/*', '<!--'],
+            end: ['*/', '-->']
+          }
+        }
+      ]
+    }
+  ]
+};
+```
+Make sure to use the same comment tag order in both "start" and "end".

--- a/index.js
+++ b/index.js
@@ -1,16 +1,27 @@
 /*jslint node:true */
-"use strict";
+'use strict';
 
-var loaderUtils = require("loader-utils");
+var loaderUtils = require('loader-utils');
+
+function regexEscape(str) {
+    return str.replace(/([\^|\$|\.|\*|\+|\?|\=|\!|\:|\\|\/|\(|\)|\[|\]|\{|\}])/gi, '\\$1');
+}
 
 function StripBlockLoader(content) {
-    var options = loaderUtils.getOptions(this) || {};
-    var startComment = options.start || 'develblock:start';
-    var endComment = options.end || 'develblock:end';
-
-    var regexPattern = new RegExp("[\\t ]*\\/\\* ?" + startComment + " ?\\*\\/[\\s\\S]*?\\/\\* ?" + endComment + " ?\\*\\/[\\t ]*\\n?", "g");
-
-    content = content.replace(regexPattern, '');
+    var options = loaderUtils.getOptions(this);
+    if (options && options.blocks) {
+        var start = Array.isArray(options.start) ? options.start : [options.start];
+        var end = Array.isArray(options.end) ? options.end : [options.end];
+        for(var i = 0; i < start.length; i++)
+        {
+            var starti = regexEscape(start[i] || '/*');
+            var endi = regexEscape(end[i] || '/*');
+            options.blocks.forEach(function (block) {
+                var regex = new RegExp('[\\t ]*' + starti + ' ?(' + block + '):start ?' + endi + '[\\s\\S]*?' + starti + ' ?\\1:end ?' + endi + '[\\t ]*\\n?', 'g');
+                content = content.replace(regex, '');
+            });
+        }
+    }
 
     if (this.cacheable) {
         this.cacheable(true);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "webpack-strip-block",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Webpack plugin to strip blocks of code that's only intended for development purposes",
     "main": "index.js",
     "repository": {
@@ -22,6 +22,9 @@
         "name": "Alexander Wunschik",
         "email": "mail@wunschik.it",
         "url": "http://www.wunschik.it"
+    }, {
+	"name": "Christian Sander",
+	"email": "christian.sander85@gmail.com"
     }],
     "license": "MIT",
     "peerDependencies": {


### PR DESCRIPTION
I needed to add the support of multiple comment tags for a project using Svelte where both JS and HTML tags where required in one file. With this simple change both single comment tags as well as arrays can be specified for the start and end keys and the replacement will happen for all specified tags.